### PR TITLE
Add bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,25 @@
+{
+  "name": "mousetrap-js",
+  "description": "Simple library for handling keyboard shortcuts (latest)",
+  "main": "mousetrap.js",
+  "authors": [
+    "Craig Campbell"
+  ],
+  "license": "Apache 2.0",
+  "keywords": [
+    "keyboard",
+    "shortcuts",
+    "events"
+  ],
+  "homepage": "https://github.com/mousetrap-js/mousetrap",
+  "moduleType": [
+    "globals"
+  ],
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ]
+}

--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,6 @@
 {
   "name": "mousetrap-js",
+  "version": "1.5.4",
   "description": "Simple library for handling keyboard shortcuts (latest)",
   "main": "mousetrap.js",
   "authors": [
@@ -16,6 +17,7 @@
     "globals"
   ],
   "ignore": [
+    "Gruntfile.js",
     "**/.*",
     "node_modules",
     "bower_components",


### PR DESCRIPTION
Adds bower.json with preliminary non-realized `1.5.4` bumped version in definition. As tags are snapshots, any new publication is triggered by a new tag/release. No need to keep it updated manually, only unregister requires bower github login of that git endpoint (this repository).
