### PR TITLE
Remove deprecated property (version)

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,5 @@
 {
   "name": "mousetrap-js",
-  "version": "1.5.4",
   "description": "Simple library for handling keyboard shortcuts (latest)",
   "main": "mousetrap.js",
   "authors": [


### PR DESCRIPTION
From bowers repo: https://github.com/bower/spec/blob/master/json.md#version

```
version

Deprecated

Use git or svn tags instead. This field is ignored by Bower.

```
