### PR TITLE
Fix bugs for the recent record plugin enhancement

### DIFF
--- a/plugins/record/README.md
+++ b/plugins/record/README.md
@@ -9,10 +9,15 @@ This extension lets you use Mousetrap to record keyboard sequences and play them
 <script>
     function recordSequence() {
         Mousetrap.record(function(sequence) {
-            // sequence is an array like ['ctrl+k', 'c']
-            alert('You pressed: ' + sequence.join(' '));
+            // sequence is an array like ['ctrl+k', 'c'] or null if stopRecord() has been called
+            if (sequence !== null) {
+                alert('You pressed: ' + sequence.join(' '));
+            } else {
+                alert('Recording of sequence has been stopped');
+            }
         });
     }
+
     function stopRecord() {
         Mousetrap.stopRecord();
     }


### PR DESCRIPTION
- fix bug for recording successively single hotkeys (using `recordSequence: false`): the same key might be recorded a second time with the `keyup` event after finishing recording which can lead to a strange behaviour that always the previous recorded key is passed to callback
- making sure that only the first recorded hotkey is returned if sequence recording is disabled

Inform callback when recording has been stopped instead of silently suppressing:
- pass `null` to callback when `stopRecord()` has been called
- Change README to reflect the change for `stopRecord()`
